### PR TITLE
Adding permissions to the webapp to read region/zone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,8 @@ radlab-launcher/deployments/*
 
 terraform.tfvars
 backend.tf
+
+staging.terraform.tfbackend
+terraform.tfvars.staging
+
+app.yaml

--- a/radlab-ui/automation/terraform/infrastructure/webapp.tf
+++ b/radlab-ui/automation/terraform/infrastructure/webapp.tf
@@ -32,7 +32,8 @@ resource "google_project_iam_member" "webapp_identity_permissions" {
     "roles/iam.serviceAccountTokenCreator",
     "roles/datastore.user",
     "roles/storage.admin", #TODO: Only give permissions to the deployment bucket
-    "roles/cloudbuild.builds.viewer"
+    "roles/cloudbuild.builds.viewer",
+    "roles/compute.viewer"
   ])
   project = module.project.project_id
   member  = "serviceAccount:${google_service_account.radlab_ui_webapp_identity.email}"


### PR DESCRIPTION
- Added a few files to `.gitignore` so it's possible to work with multiple environments
- Added IAM role to the service account attached to the webapp, so it can read `region` and `zone` from the Compute API